### PR TITLE
Build universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Currently only a Python 3 wheel of 0.4.3 is available from PyPI. The wheel should be made universal to support Python 2 as well: https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels