### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     packages=['upcloud_api', 'upcloud_api.cloud_manager'],
     download_url='https://github.com/UpCloudLtd/upcloud-python-api/archive/%s.tar.gz' % version,
     license='MIT',
+    python_requires='>=2.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
         'requests>=2.6.0',
         'six>=1.9.0'


### PR DESCRIPTION
...so the Python version dependencies are there in machine readable form, for example to assist pip etc.