### PR TITLE
Don't parse date strings in get_object_storage_network_statistics

### DIFF
--- a/docs/object_storage-mixin.md
+++ b/docs/object_storage-mixin.md
@@ -66,8 +66,8 @@ def get_object_storage_network_statistics(
 	"""
 	The network usage of an Object Storage device is metered and can be reviewed using the statistics request.
 	Object_storage is mandatory and can be a uuid or a ObjectStorage object.
-  Datetime_from is mandatory and needs to be a string example: 2020-11-03 00:00:00
-  Datetime_to is optional and needs to be a string example: 2020-11-04 00:00:00
+  Datetime_from is mandatory and needs to be a Datetime.
+  Datetime_to is optional and needs to be a Datetime.
   Interval is optional and needs to be an integer
   Bucket is optional and needs to be a list of bucket name strings
   Filename is optional and needs to be a list of filename strings

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ python_requires = >=3.6, <4
 setup_requires =
     setuptools
 install_requires =
-    python-dateutil
     requests
 packages =
     upcloud_api

--- a/test/test_object_storage.py
+++ b/test/test_object_storage.py
@@ -1,3 +1,5 @@
+import datetime
+
 import responses
 from conftest import Mock
 
@@ -63,12 +65,13 @@ class TestObjectStorage:
 
     @responses.activate
     def test_get_object_storage_network_statistics(self, manager):
-        data = Mock.mock_get(
+        Mock.mock_get(
             'object-storage/06b0e4fc-d74b-455e-a373-60cd6ca84022/stats/network/',
             response_file='object-storage_06b0e4fc-d74b-455e-a373-60cd6ca84022_stats_network.json',
         )
         res = manager.get_object_storage_network_statistics(
-            '06b0e4fc-d74b-455e-a373-60cd6ca84022', '2020-11-03 00:00:00'
+            object_storage='06b0e4fc-d74b-455e-a373-60cd6ca84022',
+            datetime_from=datetime.datetime(2020, 11, 3),
         )
 
         assert 'stats' in res

--- a/upcloud_api/cloud_manager/object_storage_mixin.py
+++ b/upcloud_api/cloud_manager/object_storage_mixin.py
@@ -1,7 +1,7 @@
+import datetime
 from typing import List, Optional
 
 from upcloud_api.object_storage import ObjectStorage
-from upcloud_api.utils import convert_datetime_string_to_object
 
 
 class ObjectStorageManager:
@@ -82,8 +82,8 @@ class ObjectStorageManager:
     def get_object_storage_network_statistics(
         self,
         object_storage,
-        datetime_from,
-        datetime_to=None,
+        datetime_from: datetime.datetime,
+        datetime_to: Optional[datetime.datetime] = None,
         interval: Optional[int] = None,
         bucket: Optional[List[str]] = None,
         filename: Optional[List[str]] = None,
@@ -96,11 +96,11 @@ class ObjectStorageManager:
         """
         The network usage of an Object Storage device is metered and can be reviewed using the statistics request.
         """
-        key_dict = {'from': convert_datetime_string_to_object(datetime_from)}
+        key_dict = {'from': datetime_from.isoformat(timespec='seconds')}
         url = f'/object-storage/{object_storage}/stats/network/?'
 
         if datetime_to:
-            key_dict['to'] = convert_datetime_string_to_object(datetime_to)
+            key_dict['to'] = datetime_to.isoformat(timespec='seconds')
         if interval:
             key_dict['interval'] = interval
         if bucket:

--- a/upcloud_api/utils.py
+++ b/upcloud_api/utils.py
@@ -1,8 +1,5 @@
 import itertools
-from datetime import datetime
 from time import sleep
-
-from dateutil import tz
 
 from upcloud_api.errors import UpCloudAPIError, UpCloudClientError
 
@@ -35,12 +32,3 @@ def get_raw_data_from_file(file):
         data = file.read()
     file.close()
     return data
-
-
-def convert_datetime_string_to_object(datetime_string):
-    """
-    Helper function to convert datetime string to object with local timezone
-    """
-    local_tz = tz.tzlocal()
-    datetime_object = datetime.strptime(datetime_string, '%Y-%m-%d %H:%M:%S')
-    return datetime_object.replace(tzinfo=local_tz, microsecond=0).isoformat()


### PR DESCRIPTION
This changes the `get_object_storage_network_statistics` method to not accept arbitrary strings that might or might not contain dates.

The parsing of those strings expects them to be in one strict format and in the local time zone, which may or may not be the case. Instead, it's simpler to just only accept `datetime.datetime` objects and call `.isoformat()` on them.

This has the happy consequence of being able to remove the `dateutil` dependency too.