### PR TITLE
Cloud manager: allow API root & user agent customisation

### DIFF
--- a/test/test_cloud_manager.py
+++ b/test/test_cloud_manager.py
@@ -34,3 +34,20 @@ class TestCloudManagerBasic:
 
         res = manager.get_timezones()
         assert json.loads(data) == res
+
+    @responses.activate
+    def test_custom_api_url(self, manager):
+        custom_url = 'https://api.upcloud.com/2'
+        normal_base = Mock.base_url
+
+        try:
+            Mock.base_url = custom_url
+            manager.api.api_root = custom_url
+
+            data = Mock.mock_get("account")
+
+            res = manager.get_account()
+            assert json.loads(data) == res
+        finally:
+            Mock.base_url = normal_base
+            manager.api.api_root = normal_base

--- a/upcloud_api/api.py
+++ b/upcloud_api/api.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from upcloud_api import __version__
 from upcloud_api.errors import UpCloudAPIError
 
 
@@ -10,14 +11,19 @@ class API:
     Handles basic HTTP communication with API.
     """
 
-    api_root = 'https://api.upcloud.com/1.3'
+    user_agent = f'upcloud-python-api/{__version__}'
 
-    def __init__(self, token, timeout=None):
+    def __init__(
+        self, token, timeout=None, api_root='https://api.upcloud.com/1.3', custom_user_agent=''
+    ):
         """
         Initialize the API with a given Authorization token and default timeout.
         """
         self.token = token
         self.timeout = timeout
+        self.api_root = api_root
+        if custom_user_agent:
+            self.user_agent = custom_user_agent
 
     def api_request(self, method, endpoint, body=None, params=None, timeout=-1):
         """
@@ -29,7 +35,7 @@ class API:
             raise Exception('Invalid/Forbidden HTTP method')
 
         url = f'{self.api_root}{endpoint}'
-        headers = {'Authorization': self.token, 'User-Agent': self._get_user_agent()}
+        headers = {'Authorization': self.token, 'User-Agent': self.user_agent}
 
         if body:
             data = json.dumps(body)
@@ -91,8 +97,3 @@ class API:
             )
 
         return res_json
-
-    def _get_user_agent(self) -> str:
-        from upcloud_api import __version__
-
-        return f'upcloud-python-api/{__version__}'

--- a/upcloud_api/cloud_manager/__init__.py
+++ b/upcloud_api/cloud_manager/__init__.py
@@ -29,7 +29,14 @@ class CloudManager(
 
     api: API
 
-    def __init__(self, username: str, password: str, timeout: int = 60) -> None:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        timeout: int = 60,
+        api_base_url: str = 'https://api.upcloud.com/1.3',
+        custom_user_agent: str = '',
+    ) -> None:
         """
         Initiates CloudManager that handles all HTTP connections with UpCloud's API.
 
@@ -45,6 +52,8 @@ class CloudManager(
         self.api = API(
             token=f'Basic {encoded_credentials}',
             timeout=timeout,
+            api_root=api_base_url,
+            custom_user_agent=custom_user_agent,
         )
 
     def authenticate(self):


### PR DESCRIPTION
Not sure if this is The Way(TM), but some user agent and API root modification is required for sandbox APIs etc so..