### PR TITLE
added missing metadata property

### DIFF
--- a/upcloud_api/server.py
+++ b/upcloud_api/server.py
@@ -71,6 +71,7 @@ class Server:
         'avoid_host',
         'login_user',
         'user_data',
+        'metadata',
     ]
 
     def __init__(self, server=None, **kwargs) -> None:
@@ -325,7 +326,6 @@ class Server:
             'hostname': self.hostname,
             'zone': self.zone,
             'title': self.title,
-            'metadata': self.metadata,
             'storage_devices': {},
         }
 


### PR DESCRIPTION
This property needs to be set to 'yes' or else cloud-init based templates won't work. This commits add this property to prepare_post_body function so that it can actually be set as required.