### PR TITLE
fix: initial pass on docs updates for correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ cluster = {
     ),
     'web2': Server(
         plan='2xCPU-4GB',
-        memory_amount=1024,
         hostname='web2.example.com',
         zone='uk-lon1',
         storage_devices=[

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cluster = {
             # OS: template storage UUID, all available os templates can be retrieved by calling manager.get_templates()
             # Note: the storage os template uuid:s will change when OS is updated. So check that the UUID is correct
             # default tier: maxIOPS, the 100k IOPS storage backend
-            Storage(os='01000000-0000-4000-8000-000030200200', size=10),
+            Storage(os='01000000-0000-4000-8000-000030240200', size=10),
             # secondary storage, hdd for reduced speed & cost
             Storage(size=100, tier='hdd')
         ],
@@ -81,7 +81,7 @@ cluster = {
         hostname='web2.example.com',
         zone='uk-lon1',
         storage_devices=[
-            Storage(os='01000000-0000-4000-8000-000030200200', size=10),
+            Storage(os='01000000-0000-4000-8000-000030240200', size=10),
             Storage(size=100, tier='hdd'),
         ],
         login_user=login_user
@@ -93,7 +93,7 @@ cluster = {
         hostname='db.example.com',
         zone='uk-lon1',
         storage_devices=[
-            Storage(os='01000000-0000-4000-8000-000030200200', size=10),
+            Storage(os='01000000-0000-4000-8000-000030240200', size=10),
             Storage(size=100),
         ],
         login_user=login_user
@@ -103,7 +103,7 @@ cluster = {
         hostname='balancer.example.com',
         zone='uk-lon1',
         storage_devices=[
-            Storage(os='01000000-0000-4000-8000-000030200200', size=10)
+            Storage(os='01000000-0000-4000-8000-000030240200', size=10)
         ],
         login_user=login_user
     )

--- a/docs/Firewall.md
+++ b/docs/Firewall.md
@@ -4,11 +4,11 @@
 
 Firewall is configured with FirewallRule objects that are specific to each server.
 Please note that a servers firewall rules are ignored if firewall is turned off
-(see [Server](/server) and [API documentation](https://www.upcloud.com/api/7-servers/#modify-server)).
+(see [Server](/server) and [API documentation](https://developers.upcloud.com/1.3/8-servers/#modify-server)).
 
 If a server is removed, its firewall and thus its firewall rules are removed too.
 
-Please refer to the [API documentation](https://www.upcloud.com/api/10-firewall/#create-firewall-rule)
+Please refer to the [API documentation](https://developers.upcloud.com/1.3/11-firewall/#create-firewall-rule)
 for more info on the attributes of FirewallRule.
 
 ## List / Get

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -47,7 +47,7 @@ server = Server(
 			hostname = "web1.example.com",
 			zone = 'uk-lon1',
 			storage_devices = [
-				Storage(os = "01000000-0000-4000-8000-000030200200", size=10),
+				Storage(os = "01000000-0000-4000-8000-000030240200", size=10),
 				Storage(size=10, tier="hdd")
 			])
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -57,7 +57,7 @@ manager.create_server( server )
 
 Currently available operating system templates can be retrieved with 'manager.get_templates()'. More information on this method can be found in storage_mixin documentation.
 
-Please refer to the [API documentation](https://www.upcloud.com/static/downloads/upcloud-apidoc-1.1.1.pdf) for the allowed Server attributes.
+Please refer to the [API documentation](https://developers.upcloud.com/1.3/8-servers/#modify-server) for the allowed Server attributes.
 
 ## Update
 
@@ -82,7 +82,7 @@ Updateable attributes:
 	"nic_model", "title", "timezone", "video_model", "vnc", "vnc_password"
 ```
 
-Please refer to the [API documentation](https://www.upcloud.com/static/downloads/upcloud-apidoc-1.1.1.pdf) for the allowed values.
+Please refer to the [API documentation](https://developers.upcloud.com/1.3/8-servers/#modify-server) for the allowed values.
 
 ### Storages
 

--- a/docs/Storage.md
+++ b/docs/Storage.md
@@ -18,7 +18,7 @@ Tiers:
 
 ### Templates
 
-Public templates such as the 01000000-0000-4000-8000-000030200200 can be cloned by anyone to get a pre-installed
+Public templates such as the 01000000-0000-4000-8000-000030240200 can be cloned by anyone to get a pre-installed
 server image that is immediately ready to go. A user can also create private templates for themselves out of
 any storage. Storages can be cloned from templates during server creation.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,6 @@ This documentation includes many code examples for administrating resources on t
 In some cases it can help to be familiar with [UpCloud's API v1.3 documentation](https://www.upcloud.com/api/).
 The code itself also has commentary & examples and is structured similarly to this documentation.
 
-If you haven't used UpCloud's API before, please see
-[Getting Started With UpCloud’s API](https://www.upcloud.com/support/getting-started-with-upclouds-api/).
-
 The documentation is divided into two parts. Usage describes the basic CRUD functionality for the object
 representations of different UpCloud resources (servers, storages, networks etc). The CloudManager describes
 the API for performing direct API calls.

--- a/upcloud_api/cloud_manager/server_mixin.py
+++ b/upcloud_api/cloud_manager/server_mixin.py
@@ -94,7 +94,7 @@ class ServerManager:
               zone = "uk-lon1",
               labels = [Label('role', 'example')],
               storage_devices = [
-                Storage(os = "01000000-0000-4000-8000-000030200200", size=10, tier=maxiops, title='Example OS disk'),
+                Storage(os = "01000000-0000-4000-8000-000030240200", size=10, tier=maxiops, title='Example OS disk'),
                 Storage(size=10, labels=[Label('usage', 'data_disk')]),
                 Storage()
               title = "My Example Server"
@@ -107,10 +107,11 @@ class ServerManager:
           (id is a running starting from 1)
         - tier defaults to maxiops
         - valid operating systems are for example:
-          * CentOS 8: 01000000-0000-4000-8000-000050010400
-          * Debian 10: 01000000-0000-4000-8000-000020050100
-          * Ubuntu 20.04: 01000000-0000-4000-8000-000030200200
-          * Windows 2019: 01000000-0000-4000-8000-000010070300
+          * Debian GNU/Linux 12 (Bookworm): 01000000-0000-4000-8000-000020070100
+          * Ubuntu Server 24.04 LTS (Noble Numbat): 01000000-0000-4000-8000-000030240200
+          * Rocky Linux 9: 01000000-0000-4000-8000-000150020100
+          * Windows Server 2022 Standard: 01000000-0000-4000-8000-000010080300
+          (for a more up-to-date listing, use UpCloud's CLI: `upctl storage list --public --template`.)
 
         """
         if isinstance(server, Server):

--- a/upcloud_api/cloud_manager/server_mixin.py
+++ b/upcloud_api/cloud_manager/server_mixin.py
@@ -111,6 +111,7 @@ class ServerManager:
           * Debian 10: 01000000-0000-4000-8000-000020050100
           * Ubuntu 20.04: 01000000-0000-4000-8000-000030200200
           * Windows 2019: 01000000-0000-4000-8000-000010070300
+
         """
         if isinstance(server, Server):
             body = server.prepare_post_body()

--- a/upcloud_api/server.py
+++ b/upcloud_api/server.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from upcloud_api.firewall import FirewallRule
 from upcloud_api.ip_address import IPAddress
 from upcloud_api.server_group import ServerGroup
-from upcloud_api.storage import Storage
+from upcloud_api.storage import STORAGE_OSES_WHICH_REQUIRE_METADATA, Storage
 from upcloud_api.upcloud_resource import UpCloudResource
 from upcloud_api.utils import try_it_n_times
 
@@ -392,6 +392,16 @@ class Server:
 
         if hasattr(self, 'metadata') and isinstance(self.metadata, bool):
             body['server']['metadata'] = "yes" if self.metadata else "no"
+
+        # metadata service has to be "yes" for certain OSes
+        for storage in self.storage_devices:
+            if (
+                hasattr(storage, 'os')
+                and storage.os
+                and storage.os in STORAGE_OSES_WHICH_REQUIRE_METADATA
+            ):
+                body['server']['metadata'] = "yes"
+                break
 
         if hasattr(self, 'server_group') and isinstance(self.server_group, ServerGroup):
             body['server']['server_group'] = f"{self.server_group.uuid}"

--- a/upcloud_api/storage.py
+++ b/upcloud_api/storage.py
@@ -2,6 +2,18 @@ from enum import Enum
 
 from upcloud_api.upcloud_resource import UpCloudResource
 
+STORAGE_OSES_WHICH_REQUIRE_METADATA = [
+    "01000000-0000-4000-8000-000020060100",  # Debian GNU/Linux 11 (Bullseye)
+    "01000000-0000-4000-8000-000020070100",  # Debian GNU/Linux 12 (Bookworm)
+    "01000000-0000-4000-8000-000030200200",  # Ubuntu Server 20.04 LTS (Focal Fossa)
+    "01000000-0000-4000-8000-000030220200",  # Ubuntu Server 22.04 LTS (Jammy Jellyfish)
+    "01000000-0000-4000-8000-000030240200",  # Ubuntu Server 24.04 LTS (Noble Numbat)
+    "01000000-0000-4000-8000-000140010100",  # AlmaLinux 8
+    "01000000-0000-4000-8000-000140020100",  # AlmaLinux 9
+    "01000000-0000-4000-8000-000150010100",  # Rocky Linux 8
+    "01000000-0000-4000-8000-000150020100",  # Rocky Linux 9
+]
+
 
 class BackupDeletionPolicy(Enum):
     """

--- a/upcloud_api/storage.py
+++ b/upcloud_api/storage.py
@@ -4,12 +4,9 @@ from upcloud_api.upcloud_resource import UpCloudResource
 
 STORAGE_OSES_WHICH_REQUIRE_METADATA = [
     "01000000-0000-4000-8000-000020070100",  # Debian GNU/Linux 12 (Bookworm)
-    "01000000-0000-4000-8000-000030200200",  # Ubuntu Server 20.04 LTS (Focal Fossa)
     "01000000-0000-4000-8000-000030220200",  # Ubuntu Server 22.04 LTS (Jammy Jellyfish)
     "01000000-0000-4000-8000-000030240200",  # Ubuntu Server 24.04 LTS (Noble Numbat)
-    "01000000-0000-4000-8000-000140010100",  # AlmaLinux 8
     "01000000-0000-4000-8000-000140020100",  # AlmaLinux 9
-    "01000000-0000-4000-8000-000150010100",  # Rocky Linux 8
     "01000000-0000-4000-8000-000150020100",  # Rocky Linux 9
 ]
 

--- a/upcloud_api/storage.py
+++ b/upcloud_api/storage.py
@@ -3,7 +3,6 @@ from enum import Enum
 from upcloud_api.upcloud_resource import UpCloudResource
 
 STORAGE_OSES_WHICH_REQUIRE_METADATA = [
-    "01000000-0000-4000-8000-000020060100",  # Debian GNU/Linux 11 (Bullseye)
     "01000000-0000-4000-8000-000020070100",  # Debian GNU/Linux 12 (Bookworm)
     "01000000-0000-4000-8000-000030200200",  # Ubuntu Server 20.04 LTS (Focal Fossa)
     "01000000-0000-4000-8000-000030220200",  # Ubuntu Server 22.04 LTS (Jammy Jellyfish)


### PR DESCRIPTION
- Found an incorrect doc in the overarching readme
- Lots of broken links to our API docs
- Set server metadata to be true if user requests an OS template which requires metadata