### PR TITLE
fix get_prices method name

### DIFF
--- a/docs/CloudManager.md
+++ b/docs/CloudManager.md
@@ -47,7 +47,7 @@ manager.get_timezones()
 
 ```python
 
-manager.get_pricing()
+manager.get_prices()
 
 ```
 


### PR DESCRIPTION
There's no `get_pricing` method implemented, but `get_prices` works.