### PR TITLE
test(tox): bump PyPy to 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           - py311
           - py312
           - py313
-          - pypy3
+          - pypy311
     permissions:
       contents: read
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39, py310, py311, py312, py313, pypy3
+envlist = py39, py310, py311, py312, py313, pypy311
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Cryptography's latest version is not available as a binary wheel for 3.10, and setting up a Rust build env seems somewhat excessive for this.